### PR TITLE
fix: multiple json in string will infinite loop

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -11,7 +11,7 @@ function extract<T extends JSONValue>(
     if(char === startBracket) {
       let section = text.slice(startIndex);
       while(section.lastIndexOf(endBracket) > 0) {
-        section = section.slice(0, section.lastIndexOf(endBracket)+1);
+        section = section.slice(0, section.substring(0, section.length - 1).lastIndexOf(endBracket) + 1);
         const result = parser(section);
         if(result !== undefined) {
           return result;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -8,6 +8,8 @@ $ /path/to/node_modules/.bin/cloc source --json
 ✨  Done in 0.23s.
 `;
 
+const objectRandomString = "{\"a\":1}{\"b\":2}";
+
 const objectWithArrayString = "Some text: { \"test\": [1, 2, 3] } Done";
 
 const arrayString = "Some text: [1, 2, 3] Done";
@@ -37,6 +39,11 @@ test("extractJSON array with object", () => {
 test("extractJSONObject", () => {
   const json = extractJSONObject(objectString);
   expect(json).toEqual({ test: { a: 1 } });
+});
+
+test("extractJSONObject", () => {
+  const json = extractJSONObject(objectRandomString);
+  expect(json).toEqual({ a: 1 });
 });
 
 test("extractJSONArray", () => {


### PR DESCRIPTION
example string:  
'{"a": 1}}' or '{"a": 1}{"b": 2}' 
this will be infinite loop